### PR TITLE
Add ability to customize the ffmpeg cli path (Resolves #1)

### DIFF
--- a/lib/src/ffmpeg/ffmpeg_command.dart
+++ b/lib/src/ffmpeg/ffmpeg_command.dart
@@ -9,7 +9,9 @@ class Ffmpeg {
   /// Executes the given [command].
   ///
   /// Provide a [ffmpegPath] to customize the path of the ffmpeg cli.
-  /// If `null`, the "ffmpeg" from path is used.
+  /// For example, [ffmpegPath] might be `/opt/homebrew/bin/ffmpeg` on macOS
+  /// or `C:\ffmpeg\ffmpeg.exe` on Windows. If `null`, the `ffmpeg`
+  /// from path is used.
   Future<Process> run(FfmpegCommand command, {String? ffmpegPath}) {
     return Process.start(
       ffmpegPath ?? 'ffmpeg',
@@ -63,7 +65,10 @@ class FfmpegCommand {
   List<String> toCli() {
     return [
       for (final input in inputs) ...input.args,
-      for (final arg in args) ...["-${arg.name}", if (arg.value != null) arg.value!],
+      for (final arg in args) ...[
+        "-${arg.name}",
+        if (arg.value != null) arg.value!
+      ],
       if (filterGraph != null) ...[
         '-filter_complex',
         filterGraph!.toCli(),
@@ -137,7 +142,7 @@ class CliArg {
   final String name;
   final String? value;
 
-  String toCli() => '-$name ${(value != null) ? value : ""}';
+  String toCli() => '-$name ${(value != null) ?  value : ""}';
 }
 
 /// A filter graph that describes how FFMPEG should compose various assets

--- a/lib/src/ffmpeg/ffmpeg_command.dart
+++ b/lib/src/ffmpeg/ffmpeg_command.dart
@@ -7,9 +7,12 @@ import 'package:ffmpeg_cli/src/ffmpeg/log_level.dart';
 /// Executes FFMPEG commands from Dart.
 class Ffmpeg {
   /// Executes the given [command].
-  Future<Process> run(FfmpegCommand command) {
+  ///
+  /// Provide a [ffmpegPath] to customize the path of the ffmpeg cli.
+  /// If `null`, the "ffmpeg" from path is used.
+  Future<Process> run(FfmpegCommand command, {String? ffmpegPath}) {
     return Process.start(
-      'ffmpeg',
+      ffmpegPath ?? 'ffmpeg',
       command.toCli(),
     );
   }
@@ -60,10 +63,7 @@ class FfmpegCommand {
   List<String> toCli() {
     return [
       for (final input in inputs) ...input.args,
-      for (final arg in args) ...[
-        "-${arg.name}",
-        if (arg.value != null) arg.value!
-      ],
+      for (final arg in args) ...["-${arg.name}", if (arg.value != null) arg.value!],
       if (filterGraph != null) ...[
         '-filter_complex',
         filterGraph!.toCli(),
@@ -137,7 +137,7 @@ class CliArg {
   final String name;
   final String? value;
 
-  String toCli() => '-$name ${(value != null) ?  value : ""}';
+  String toCli() => '-$name ${(value != null) ? value : ""}';
 }
 
 /// A filter graph that describes how FFMPEG should compose various assets

--- a/lib/src/ffmpeg/ffmpeg_command_builder.dart
+++ b/lib/src/ffmpeg/ffmpeg_command_builder.dart
@@ -135,8 +135,14 @@ class FfmpegBuilder {
   /// and returns an [FfmpegCommand] that generates a corresponding video,
   /// which is rendered to the given [outputFilepath].
   ///
+  /// Provide a [ffmpegPath] to customize the path of the ffmpeg cli.
+  /// For example, [ffmpegPath] might be `/opt/homebrew/bin/ffmpeg` on macOS
+  /// or `C:\ffmpeg\ffmpeg.exe` on Windows. If `null`, the `ffmpeg`
+  /// from path is used.
+  ///
   /// To run the command, see [FfmpegCommand].
   FfmpegCommand build({
+    String? ffmpegPath,
     required List<CliArg> args,
     FfmpegStream? mainOutStream,
     required String outputFilepath,
@@ -148,6 +154,7 @@ class FfmpegBuilder {
 
     ffmpegBuilderLog.info('Filter chains: $_filterChains');
     return FfmpegCommand.complex(
+      ffmpegPath: ffmpegPath,
       inputs: _inputs.keys.toList(),
       args: args,
       filterGraph: FilterGraph(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,9 +4,10 @@ description: Run FFMPEG CLI commands from Dart.
 homepage: https://github.com/Flutter-Bounty-Hunters/ffmpeg_cli
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  collection: ^1.18.0
   json_annotation: ^4.8.1
   logging: ^1.2.0
 

--- a/test/ffmpeg/ffmpeg_command_test.dart
+++ b/test/ffmpeg/ffmpeg_command_test.dart
@@ -5,8 +5,7 @@ void main() {
   group("FFMPEG", () {
     group("command", () {
       test("serializes to CLI arguments", () {
-        const outputStream =
-            FfmpegStream(videoId: "[final_v]", audioId: "[final_a]");
+        const outputStream = FfmpegStream(videoId: "[final_v]", audioId: "[final_a]");
 
         final command = FfmpegCommand.complex(
           inputs: [
@@ -29,10 +28,7 @@ void main() {
                   const FfmpegStream(videoId: "[2:v]", audioId: "[2:a]"),
                 ],
                 filters: [
-                  ConcatFilter(
-                      segmentCount: 3,
-                      outputVideoStreamCount: 1,
-                      outputAudioStreamCount: 1),
+                  ConcatFilter(segmentCount: 3, outputVideoStreamCount: 1, outputAudioStreamCount: 1),
                 ],
                 outputs: [
                   outputStream,
@@ -45,18 +41,76 @@ void main() {
 
         expect(
           command.toCli(),
-          [
-            "-i", "assets/intro.mp4", //
-            "-i", "assets/content.mp4", //
-            "-i", "assets/outro.mov", //
-            "-map", "[final_v]", //
-            "-map", "[final_a]", //
-            "-y",
-            "-vsync", "2", //
-            "-filter_complex",
-            "[0:v] [0:a] [1:v] [1:a] [2:v] [2:a] concat=n=3:v=1:a=1 [final_v] [final_a]",
-            "/my/output/file.mp4",
+          const CliCommand(
+            executable: 'ffmpeg',
+            args: [
+              "-i", "assets/intro.mp4", //
+              "-i", "assets/content.mp4", //
+              "-i", "assets/outro.mov", //
+              "-map", "[final_v]", //
+              "-map", "[final_a]", //
+              "-y",
+              "-vsync", "2", //
+              "-filter_complex",
+              "[0:v] [0:a] [1:v] [1:a] [2:v] [2:a] concat=n=3:v=1:a=1 [final_v] [final_a]",
+              "/my/output/file.mp4",
+            ],
+          ),
+        );
+      });
+
+      test("allows custom ffmpeg path for simple commands", () {
+        const command = FfmpegCommand.simple(
+          ffmpegPath: '/opt/homebrew/bin/ffmpeg',
+          outputFilepath: '/my/output/file.mp4',
+        );
+
+        expect(
+          command.toCli(),
+          const CliCommand(
+            executable: '/opt/homebrew/bin/ffmpeg',
+            args: ['/my/output/file.mp4'],
+          ),
+        );
+      });
+
+      test("allows custom ffmpeg path for complex commands", () {
+        final commandBuilder = FfmpegBuilder();
+
+        final inputStream = commandBuilder.addAsset("assets/bee.mp4");
+        final outputStream = commandBuilder.createStream(hasVideo: true, hasAudio: true);
+
+        commandBuilder.addFilterChain(
+          FilterChain(
+            inputs: [inputStream],
+            filters: [],
+            outputs: [outputStream],
+          ),
+        );
+
+        final command = commandBuilder.build(
+          ffmpegPath: '/opt/homebrew/bin/ffmpeg',
+          args: [
+            CliArg(name: 'map', value: outputStream.videoId!),
+            CliArg(name: 'map', value: outputStream.audioId!),
+            const CliArg(name: 'vsync', value: '2'),
           ],
+          outputFilepath: '/output/test_render.mp4',
+        );
+
+        expect(
+          command.toCli(),
+          const CliCommand(
+            executable: '/opt/homebrew/bin/ffmpeg',
+            args: [
+              '-i', 'assets/bee.mp4', //
+              '-map', '[comp_0_v]', //
+              '-map', '[comp_0_a]', //
+              '-vsync', '2', //
+              '-filter_complex', '[0:v] [0:a]  [comp_0_v] [comp_0_a]', //
+              '/output/test_render.mp4',
+            ],
+          ),
         );
       });
     });


### PR DESCRIPTION
Add ability to customize the ffmpeg cli path. Resolves #1 

Currently, the cli is invoked always using the ffmpeg from path.

This PR adds the option to customize the ffmpeg cli path. Users will be able to specify the path as a named argument:

```dart
 final process = await Ffmpeg().run(cliCommand, ffmpegPath: '/opt/homebrew/bin/ffmpeg');
```

The whole path must be provided, including the executable name.