### PR TITLE
Images to video generation cli command tests added (Resolves #11)

### DIFF
--- a/test/ffmpeg/ffmpeg_command_test.dart
+++ b/test/ffmpeg/ffmpeg_command_test.dart
@@ -113,6 +113,42 @@ void main() {
           ),
         );
       });
+
+      test("converts a group of images to a video", () {
+        final command = FfmpegCommand.simple(
+          inputs: [
+            // file%d.png represents images named like file0.png, file1.png, file2.png, etc.
+            FfmpegInput.asset("assets/images/file%d.png"),
+
+            FfmpegInput.asset("assets/audio/audio.mp3"),
+          ],
+          args: [
+            const CliArg(name: 'y'),
+            const CliArg(name: 'c:a', value: 'aac'),
+            const CliArg(name: 'qscale:v', value: '1'),
+          ],
+          outputFilepath: 'assets/output/file.mp4',
+        );
+
+        expect(
+          command.toCli(),
+          const CliCommand(
+            executable: 'ffmpeg',
+            args: [
+              "-i",
+              "assets/images/file%d.png",
+              "-i",
+              "assets/audio/audio.mp3",
+              "-y",
+              "-c:a",
+              "aac",
+              "-qscale:v",
+              "1",
+              "assets/output/file.mp4"
+            ],
+          ),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Images to video generation cli command tests added (Resolves #11)

This PR adds tests for a ffmpeg operation that takes in a group of images and an audio file and outputs a video file.

